### PR TITLE
Fix mtgcard tag plugin rescue flow

### DIFF
--- a/scripts/mtgcard.js
+++ b/scripts/mtgcard.js
@@ -167,7 +167,9 @@ async function fetchCardDataMeta(argv) {
       hexo.log.info(`Request Scryfall API: ${scryfallAPIPath}`);
       await sleep(500);
     } catch (err) {
-      return {
+      hexo.log.warn(`API \"${scryfallAPIPath}\" not fetch!`);
+
+      data = {
         failure: true,
         data:
           "<p><em>Error getting card data: <br />" +
@@ -356,11 +358,12 @@ hexo.extend.tag.register(
         hexo.log.info(`Request Scryfall API: ${scryfallAPIPath}`);
         await sleep(500);
       } catch (err) {
-        return {
+        hexo.log.warn(`API \"${scryfallAPIPath}\" not fetch!`);
+
+        data = {
           failure: true,
           data:
             "<p><em>Error getting card data: <br />" +
-            `Arguments: ${argv}<br />` +
             `Query: ${JSON.stringify(argv)}<br />` +
             `API Path: ${scryfallAPIPath}</em></p>`,
         };

--- a/scripts/mtgcard.js
+++ b/scripts/mtgcard.js
@@ -171,7 +171,6 @@ async function fetchCardDataMeta(argv) {
         failure: true,
         data:
           "<p><em>Error getting card data: <br />" +
-          `Arguments: ${argv}<br />` +
           `Query: ${JSON.stringify(argv)}<br />` +
           `API Path: ${scryfallAPIPath}</em></p>`,
       };
@@ -199,34 +198,34 @@ hexo.extend.tag.register(
 
     let card = await fetchCardDataMeta(argv);
     let html, cardImageUrl;
-    if (undefined === card) {
-      argv.tooltip = false;
-      card["image_uris"]["large"] = "#";
-      card["scryfall_uri"] = "#";
+
+    if (card?.failure) {
+      html = card.data;
+    } else {
+      if (card.image_uris !== undefined) {
+        cardImageUrl = card.image_uris.large;
+      } else {
+        cardImageUrl = card.card_faces[0].image_uris.large;
+      }
+      if (argv.tooltip) {
+        if (argv.alt) {
+          html = render(tpl.tooltip, {
+            URL: card.scryfall_uri,
+            NAME: decodeURI(argv.alt),
+            IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+          });
+        } else {
+          html = render(tpl.tooltip, {
+            URL: card.scryfall_uri,
+            NAME: argv.name,
+            IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+          });
+        }
+      } else {
+        html = render(tpl.image, { IMG: cardImageUrl });
+      }
     }
 
-    if (card.image_uris !== undefined) {
-      cardImageUrl = card.image_uris.large;
-    } else {
-      cardImageUrl = card.card_faces[0].image_uris.large;
-    }
-    if (argv.tooltip) {
-      if (argv.alt) {
-        html = render(tpl.tooltip, {
-          URL: card.scryfall_uri,
-          NAME: decodeURI(argv.alt),
-          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-        });
-      } else {
-        html = render(tpl.tooltip, {
-          URL: card.scryfall_uri,
-          NAME: argv.name,
-          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-        });
-      }
-    } else {
-      html = render(tpl.image, { IMG: cardImageUrl });
-    }
     return html;
   },
   { async: true }
@@ -245,30 +244,29 @@ hexo.extend.tag.register(
 
     let card = await fetchCardDataMeta(argv);
     let html, cardImageUrl;
-    if (undefined === card) {
-      argv.tooltip = false;
-      card["image_uris"]["large"] = "#";
-      card["scryfall_uri"] = "#";
-    }
 
-    if (card.image_uris !== undefined) {
-      cardImageUrl = card.image_uris.large;
+    if (card?.failure) {
+      html = card.data;
     } else {
-      cardImageUrl = card.card_faces[0].image_uris.large;
-    }
+      if (card.image_uris !== undefined) {
+        cardImageUrl = card.image_uris.large;
+      } else {
+        cardImageUrl = card.card_faces[0].image_uris.large;
+      }
 
-    if (argv.alt) {
-      html = render(tpl.tooltip, {
-        URL: card.scryfall_uri,
-        NAME: decodeURI(argv.alt),
-        IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-      });
-    } else {
-      html = render(tpl.tooltip, {
-        URL: card.scryfall_uri,
-        NAME: argv.name,
-        IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-      });
+      if (argv.alt) {
+        html = render(tpl.tooltip, {
+          URL: card.scryfall_uri,
+          NAME: decodeURI(argv.alt),
+          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+        });
+      } else {
+        html = render(tpl.tooltip, {
+          URL: card.scryfall_uri,
+          NAME: argv.name,
+          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+        });
+      }
     }
 
     return html;

--- a/scripts/mtgcard.js
+++ b/scripts/mtgcard.js
@@ -167,12 +167,14 @@ async function fetchCardDataMeta(argv) {
       hexo.log.info(`Request Scryfall API: ${scryfallAPIPath}`);
       await sleep(500);
     } catch (err) {
-      return (
-        "<p><em>Error getting card data: <br />" +
-        `Arguments: ${args}<br />` +
-        `Query: ${JSON.stringify(argv)}<br />` +
-        `API Path: ${scryfallAPIPath}</em></p>`
-      );
+      return {
+        failure: true,
+        data:
+          "<p><em>Error getting card data: <br />" +
+          `Arguments: ${argv}<br />` +
+          `Query: ${JSON.stringify(argv)}<br />` +
+          `API Path: ${scryfallAPIPath}</em></p>`,
+      };
     }
   }
 
@@ -356,12 +358,14 @@ hexo.extend.tag.register(
         hexo.log.info(`Request Scryfall API: ${scryfallAPIPath}`);
         await sleep(500);
       } catch (err) {
-        return (
-          "<p><em>Error getting card data: <br />" +
-          `Arguments: ${args}<br />` +
-          `Query: ${JSON.stringify(argv)}<br />` +
-          `API Path: ${scryfallAPIPath}</em></p>`
-        );
+        return {
+          failure: true,
+          data:
+            "<p><em>Error getting card data: <br />" +
+            `Arguments: ${argv}<br />` +
+            `Query: ${JSON.stringify(argv)}<br />` +
+            `API Path: ${scryfallAPIPath}</em></p>`,
+        };
       }
     }
 

--- a/scripts/mtgcard.js
+++ b/scripts/mtgcard.js
@@ -376,22 +376,26 @@ hexo.extend.tag.register(
     } else {
       cardImageUrl = card.card_faces[0].image_uris.large;
     }
-    if (argv.tooltip) {
-      if (argv.alt) {
-        html = render(tpl.tooltip, {
-          URL: card.scryfall_uri,
-          NAME: decodeURI(argv.alt),
-          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-        });
-      } else {
-        html = render(tpl.tooltip, {
-          URL: card.scryfall_uri,
-          NAME: card.name,
-          IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
-        });
-      }
+    if (card?.failure) {
+      html = card.data;
     } else {
-      html = render(tpl.image, { IMG: cardImageUrl });
+      if (argv.tooltip) {
+        if (argv.alt) {
+          html = render(tpl.tooltip, {
+            URL: card.scryfall_uri,
+            NAME: decodeURI(argv.alt),
+            IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+          });
+        } else {
+          html = render(tpl.tooltip, {
+            URL: card.scryfall_uri,
+            NAME: card.name,
+            IMG: render(tpl.tooltip_image, { IMG: cardImageUrl }),
+          });
+        }
+      } else {
+        html = render(tpl.image, { IMG: cardImageUrl });
+      }
     }
     return html;
   },

--- a/scripts/mtgcard.js
+++ b/scripts/mtgcard.js
@@ -372,14 +372,16 @@ hexo.extend.tag.register(
 
     let card = data;
     let html, cardImageUrl;
-    if (card.image_uris !== undefined) {
-      cardImageUrl = card.image_uris.large;
-    } else {
-      cardImageUrl = card.card_faces[0].image_uris.large;
-    }
+
     if (card?.failure) {
       html = card.data;
     } else {
+      if (card.image_uris !== undefined) {
+        cardImageUrl = card.image_uris.large;
+      } else {
+        cardImageUrl = card.card_faces[0].image_uris.large;
+      }
+
       if (argv.tooltip) {
         if (argv.alt) {
           html = render(tpl.tooltip, {


### PR DESCRIPTION
Previously, when mtgcard tag plugin raise error, it will rescue to (HTML) string,
but the following structure treat the variable is a object and continuing process.
This will fix tthe problem.